### PR TITLE
Fixed check receipt datetime format

### DIFF
--- a/CheckReceiptSDK/Resources/Urls.cs
+++ b/CheckReceiptSDK/Resources/Urls.cs
@@ -4,7 +4,7 @@ namespace CheckReceiptSDK.Resources
 {
     internal static class Urls
     {
-        private const string DateFormat = "yyyy-MM-ddThh:mm:ss";
+        private const string DateFormat = "yyyy-MM-ddTHH:mm:ss";
 
         internal const string Registration = "https://proverkacheka.nalog.ru:9999/v1/mobile/users/signup";
         internal const string Login = "https://proverkacheka.nalog.ru:9999/v1/mobile/users/login";


### PR DESCRIPTION
При проверке существования чека возвращается ошибка 406, причина в том, что время некорректное. 
hh - 12 часовой формат времени, т.е в моем кейсе вместо 21:14, подставляется время 09:14 и проверка успешно проваливается.